### PR TITLE
feat: keep mise lockfile in sync on tool updates

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -14,7 +14,8 @@
     "github>mirceanton/renovate-config//semantic-commits.json5",
     "github>mirceanton/renovate-config//custom-manager-github-links.json5",
     "github>mirceanton/renovate-config//custom-manager-yaml.json5",
-    "github>mirceanton/renovate-config//custom-manager-actions.json5"
+    "github>mirceanton/renovate-config//custom-manager-actions.json5",
+    "github>mirceanton/renovate-config//mise.json5"
   ],
   "packageRules": [
     // Package Scheduling

--- a/mise.json5
+++ b/mise.json5
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  // Keep the mise lockfile (mise.lock) in sync whenever Renovate bumps a tool
+  // version. `mise lock` re-resolves the new version and refreshes the
+  // checksums/URLs for every platform already present in the lockfile, then the
+  // updated mise.lock is committed alongside the .mise.toml change.
+  "mise": {
+    "postUpgradeTasks": {
+      "commands": ["mise lock"],
+      "fileFilters": ["mise.lock"],
+      "executionMode": "branch"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a shared `mise.json5` preset (wired into `default.json5`) that keeps the mise lockfile (`mise.lock`) in sync whenever Renovate bumps a mise tool version.

When the `mise` manager updates a version in `.mise.toml`, a `postUpgradeTask` runs `mise lock`, which re-resolves the new version and refreshes the checksums/URLs for **every platform** in the lockfile, then commits the updated `mise.lock` alongside the change (`fileFilters: ["mise.lock"]`, `executionMode: branch`).

## Notes

- Uses `mise lock` (not `mise install`): `mise install` only updates the current platform, leaving other platforms stale; `mise lock` refreshes all platforms.
- The self-hosted Renovate runner already allows both `mise install` and `mise lock` (`RENOVATE_ALLOWED_COMMANDS`), so no runner change is needed.
- The home-ops-local `mise` block in `.renovate/managers.json5` becomes redundant once this merges and can be removed.